### PR TITLE
add 'slowMode' parameter on function loadLpAddressMap

### DIFF
--- a/scripts/fetchLpAddressMap.js
+++ b/scripts/fetchLpAddressMap.js
@@ -6,7 +6,8 @@ dotenv.config();
 async function fetchAndWrite() {
   const adapter = new wr.WingRidersAdapter({ projectId: process.env.BLOCKFROST_PROJECT_ID });
 
-  const lpAddressMap = await adapter.loadLpAddressMap();
+  const slowMode = false; // you can set it to true if blockfrost gives you HTTP 429 Error
+  const lpAddressMap = await adapter.loadLpAddressMap(slowMode);
 
   fs.writeFileSync("dist/addressMap.json", JSON.stringify(lpAddressMap, null, "  "));
 }


### PR DESCRIPTION
Hi,

When using your package I encountered a problem when calling loadLpAddressMap():
`429 Too Many Requests`

Maybe it's due to my blockfrost api key being the free tier or maybe it's because blockfrost recently changed its limits, I don't know.

Anyway I added an optional parameter to the loadLpAddressMap function which allow to run it in slowMode. The new parameters is false by default for backward compatibility

I changed the `scripts/fetchLpAddressMap.js` file to show the new capability.